### PR TITLE
fix: Clean markdown from generated SQL query

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -73,6 +73,12 @@ def query():
         sql_query = rag_chain.invoke(natural_language_query)
         print(f"Generated SQL: {sql_query}")
 
+        # Clean up the generated query from markdown, if present
+        if "```sql" in sql_query:
+            sql_query = sql_query.split("```sql")[1].split("```")[0].strip()
+        elif "```" in sql_query:
+            sql_query = sql_query.split("```")[1].split("```")[0].strip()
+
         engine = create_engine(db_uri)
         with engine.connect() as connection:
             results = connection.execute(text(sql_query)).mappings().all()


### PR DESCRIPTION
This commit fixes a bug where the application would crash if the language model wrapped the generated SQL query in markdown code fences (e.g., ```sql ... ```).

Logic has been added to `app/app.py` to strip these markdown fences from the LLM's output before the query is executed against the database. This prevents a syntax error and makes the application more robust to variations in model output.