### PR TITLE
Fix: Correct import error in app.py

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -7,7 +7,7 @@ from langchain_community.chat_models import ChatOllama
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
-from app.schema_utils import get_schema_documents_from_text
+from schema_utils import get_schema_documents_from_text
 
 # It's a good practice to use a .env file for configuration
 from dotenv import load_dotenv


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError` that occurred when running `app/app.py` directly. The import statement for `schema_utils` was using an absolute path (`app.schema_utils`) which is incorrect when the script is run from within the `app` directory.

The import has been changed to a relative one (`from schema_utils import ...`) to resolve the issue and allow the application to start correctly.