### PR TITLE
Fix: Automatically correct SQL Server connection URI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -56,6 +56,11 @@ def index():
 @app.route('/query', methods=['POST'])
 def query():
     db_uri = request.form.get('db_uri')
+    # Automatically correct common SQL Server connection string issue
+    if db_uri and db_uri.startswith('sqlserver://'):
+        db_uri = db_uri.replace('sqlserver://', 'mssql+pyodbc://', 1)
+        print(f"Corrected DB URI to: {db_uri}")
+
     natural_language_query = request.form.get('query')
     schema_text = request.form.get('schema_text')
     model_choice = request.form.get('model_choice', 'local') # Default to local


### PR DESCRIPTION
This commit adds logic to `app/app.py` to automatically correct a common user error in the SQL Server connection string.

The application now checks for a URI starting with the incorrect `sqlserver://` prefix and replaces it with the correct `mssql+pyodbc://` prefix required by the `pyodbc` driver. This resolves the persistent `sqlalchemy.exc.NoSuchModuleError` and improves the application's robustness and user-friendliness.